### PR TITLE
Added explain analyze query plan to recommendation prompt

### DIFF
--- a/config/slower.php
+++ b/config/slower.php
@@ -13,10 +13,13 @@ return [
     ],
     'ai_recommendation' => env('SLOWER_AI_RECOMMENDATION', true),
     'recommendation_model' => env('SLOWER_AI_RECOMMENDATION_MODEL', 'gpt-4'),
+    'recommendation_use_explain' => env('SLOWER_AI_RECOMMENDATION_USE_EXPLAIN', true),
+    'ignore_explain_queries' => env('SLOWER_IGNORE_EXPLAIN_QUERIES', true),
+    'ignore_insert_queries' => env('SLOWER_IGNORE_INSERT_QUERIES', true),
     'open_ai' => [
         'api_key' => env('OPENAI_API_KEY'),
         'organization' => env('OPENAI_ORGANIZATION'),
         'request_timeout' => env('OPENAI_TIMEOUT'),
     ],
-    'prompt' => env('SLOWER_PROMPT', 'As a distinguished database optimization expert, your expertise is invaluable for refining SQL queries to achieve maximum efficiency. Please examine the SQL statement provided below. Based on your analysis, could you recommend sophisticated indexing techniques or query modifications that could significantly improve performance and scalability?'),
+    'prompt' => env('SLOWER_PROMPT', 'As a distinguished database optimization expert, your expertise is invaluable for refining SQL queries to achieve maximum efficiency. Schema json provide list of indexes and column definitions for each table in query. Also analyse the output of EXPLAIN ANALYSE and provide recommendations to optimize query. Please examine the SQL statement provided below including EXPLAIN ANALYSE query plan. Based on your analysis, could you recommend sophisticated indexing techniques or query modifications that could significantly improve performance and scalability?'),
 ];

--- a/src/Services/RecommendationService.php
+++ b/src/Services/RecommendationService.php
@@ -19,7 +19,7 @@ class RecommendationService
             'Connection: ' . $record->connection . PHP_EOL .
             'Connection Name: ' . $record->connection_name . PHP_EOL .
             'Schema: ' . json_encode($schema, JSON_PRETTY_PRINT) . PHP_EOL .
-            'Sql: ' . $record->raw_sql . PHP_EOL;
+            'Sql: ' . $record->sql . PHP_EOL;
 
         if (config('slower.recommendation_use_explain', false)) {
             $plan = collect(DB::select('explain analyse ' . $record->raw_sql))->implode('QUERY PLAN', PHP_EOL);

--- a/src/SlowerServiceProvider.php
+++ b/src/SlowerServiceProvider.php
@@ -59,7 +59,11 @@ class SlowerServiceProvider extends PackageServiceProvider
     private function registerDatabaseListener(): void
     {
         if (config('slower.enabled')) {
-            DB::whenQueryingForLongerThan(config('slower.threshold', 10000), function (Connection $connection, QueryExecuted $event) {
+            DB::listen(function (QueryExecuted $event) {
+                if($event->time < config('slower.threshold', 10000)) {
+                    return;
+                }
+
                 if(config('slower.ignore_explain_queries', true) && Str::startsWith($event->sql, 'EXPLAIN')) {
                     return;
                 }
@@ -68,8 +72,8 @@ class SlowerServiceProvider extends PackageServiceProvider
                     return;
                 }
 
-                $this->createRecord($event, $connection);
-                $this->notify($event, $connection);
+                $this->createRecord($event, $event->connection);
+                $this->notify($event, $event->connection);
             });
         }
     }

--- a/src/SlowerServiceProvider.php
+++ b/src/SlowerServiceProvider.php
@@ -60,6 +60,14 @@ class SlowerServiceProvider extends PackageServiceProvider
     {
         if (config('slower.enabled')) {
             DB::whenQueryingForLongerThan(config('slower.threshold', 10000), function (Connection $connection, QueryExecuted $event) {
+                if(config('slower.ignore_explain_queries', true) && Str::startsWith($event->sql, 'EXPLAIN')) {
+                    return;
+                }
+
+                if(config('slower.ignore_insert_queries', true) && stripos($event->sql, 'insert') === 0) {
+                    return;
+                }
+
                 $this->createRecord($event, $connection);
                 $this->notify($event, $connection);
             });


### PR DESCRIPTION
### Description

- Explain analyze query plan has been added to prompt for more relevant recommendations. This provide more detailed information to the LLM about existing indexes utilization, actual query time etc. so LLM can provide more usefull answers.
This feature can be enabled/disabled by `recommendation_use_explain` configuration.
- Two parameters `ignore_explain_queries` and `ignore_insert_queries` have been added into config to provide ability to disable logging **EXPLAIN** and **INSERT** queries.
- **extractIndexesAndSchemaFromRecord** function was refactored to use schema and indexes from all tables used in SQL query instead of SlowLog table schema and indexes because it doesent provide any usefull information for LLM about query. So, it means if query use multiple tables then each table with indexes and schema will be transferred to LLM for provide more usefull answers. 
- Prompt text was changed to instruct LLM to use query plan and tables schema.

After this changes prompt will use more tokens but LLM will provide more usefull recommendations: 
- Full queries for creating indexes; 
- Completely redesigned optimized initial query; 
- Recommendations for database configurations; 
- Architecture recommendations (partitioning, etc.)
![image](https://github.com/halilcosdu/laravel-slower/assets/13642249/d252600b-ec98-4c9f-a81f-0571fe7d3bec)
![image](https://github.com/halilcosdu/laravel-slower/assets/13642249/72f52b38-9582-4ac1-ad5f-ccb266c9adc9)
