### PR TITLE
Add support for managing multiple AI services using a Manager class

### DIFF
--- a/config/slower.php
+++ b/config/slower.php
@@ -7,6 +7,7 @@ use HalilCosdu\Slower\Models\SlowLog;
 return [
     'enabled' => env('SLOWER_ENABLED', true),
     'threshold' => env('SLOWER_THRESHOLD', 10000),
+    'ai_service' => env('SLOWER_AI_SERVICE', 'openai'),
     'resources' => [
         'table_name' => (new SlowLog)->getTable(),
         'model' => SlowLog::class,

--- a/src/AiServiceDrivers/AiServiceManager.php
+++ b/src/AiServiceDrivers/AiServiceManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace HalilCosdu\Slower\AiServiceDrivers;
+
+use GuzzleHttp\Client;
+use Illuminate\Support\Manager;
+use InvalidArgumentException;
+use OpenAI as OpenAIFactory;
+
+class AiServiceManager extends Manager
+{
+    public function createOpenaiDriver(): OpenAiDriver
+    {
+        $apiKey       = config('slower.open_ai.api_key');
+        $organization = config('slower.open_ai.organization');
+        $timeout      = config('slower.open_ai.request_timeout', 30);
+        if ( !is_string($apiKey) || ($organization !== null && !is_string($organization)) ) {
+            throw new InvalidArgumentException(
+                'The OpenAI API Key is missing. Please publish the [slower.php] configuration file and set the [api_key].'
+            );
+        }
+        $openAI = OpenAIFactory::factory()
+            ->withApiKey($apiKey)
+            ->withOrganization($organization)
+            ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
+            ->withHttpClient(new Client([ 'timeout' => $timeout ]))
+            ->make();
+        return new OpenAiDriver($openAI);
+    }
+
+    public function getDefaultDriver(): string
+    {
+        return config('slower.ai_service', 'openai');
+    }
+}

--- a/src/AiServiceDrivers/Contracts/AiServiceDriver.php
+++ b/src/AiServiceDrivers/Contracts/AiServiceDriver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace HalilCosdu\Slower\AiServiceDrivers\Contracts;
+
+interface AiServiceDriver
+{
+    public function analyze(string $userMessage): ?string;
+}

--- a/src/AiServiceDrivers/OpenAiDriver.php
+++ b/src/AiServiceDrivers/OpenAiDriver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HalilCosdu\Slower\AiServiceDrivers;
+
+use HalilCosdu\Slower\AiServiceDrivers\Contracts\AiServiceDriver;
+use OpenAI\Client;
+
+class OpenAiDriver implements AiServiceDriver
+{
+    public function __construct(protected Client $client)
+    {
+    }
+
+    public function analyze(string $userMessage): ?string
+    {
+        $result = $this->client->chat()->create([
+            'model' => config('slower.recommendation_model', 'gpt-4'),
+            'messages' => [
+                ['role' => 'system', 'content' => config('slower.prompt')],
+                ['role' => 'user', 'content' => $userMessage],
+            ],
+        ]);
+        return $result->choices[0]->message->content ?? null;
+    }
+}

--- a/tests/SlowerTest.php
+++ b/tests/SlowerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use HalilCosdu\Slower\AiServiceDrivers\AiServiceManager;
+use HalilCosdu\Slower\AiServiceDrivers\Contracts\AiServiceDriver;
 use HalilCosdu\Slower\Services\RecommendationService;
 use HalilCosdu\Slower\Slower;
 
@@ -43,5 +45,14 @@ describe('analyze', function () {
         $this->mockedRecommendationService->shouldReceive('getRecommendation')->once()->with($mockedModel);
         $result = $this->slower->analyze($mockedModel);
         expect($result)->toBe($expectedResult);
+    });
+});
+
+
+describe('ai-service', function () {
+    it('returns an instance of the configured driver', function () {
+        expect(
+            app(AiServiceManager::class)->driver(config('slower.ai_service'))
+        )->toBeInstanceOf(AiServiceDriver::class);
     });
 });


### PR DESCRIPTION
This pull request introduces a new feature that enables the management of multiple AI services within the package using the Laravel Manager class. With this addition, developers can easily configure and switch between various AI services when using **Slower**, enhancing flexibility and reducing the complexity of managing AI service integrations 
also extend the drivers by their own implementation 
this Improves extensibility and scalability for developers integrating different AI services.

**Key Changes:**
The driver can be configured in the config file
Implemented a Manager class that handles multiple AI service drivers.
Added support for configuration of multiple AI services.
Ensured seamless switching between different AI services at runtime.


**Additional Notes:**
This feature can be extended in the future by adding support for additional AI service drivers.
The config file can be refactored to separate the config for each AI service in specific array **(breaking change)**
We can work on the Unit/Integration Tests later to ensure that the functionality works as expected and covering all the code with edge cases

