### PR TITLE
v2.2.0 — maintenance & quality pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.2 ]
+        php: [ 8.4, 8.3, 8.2 ]
         laravel: [ 11.*, 12.*, 13.*]
         stability: [ prefer-lowest, prefer-stable ]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `laravel-slower` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- **Safe EXPLAIN handling.** Recommendation analysis now uses a non-executing `EXPLAIN` (never `EXPLAIN ANALYZE`), resolves the captured query's own connection, picks the correct statement form per database driver (`pgsql`/`mysql` → `EXPLAIN`, `sqlite` → `EXPLAIN QUERY PLAN`), skips multi-statement input, and reports EXPLAIN failures without breaking the analysis flow. Previously, `explain analyse` was run unconditionally, which both fails on MySQL/SQLite and can execute the underlying query against production data.
+- **Retryable recommendations.** A record is only marked `is_analyzed` when the AI actually returns a recommendation. Empty results stay `is_analyzed=false` so they are retried on the next `slower:analyze` run instead of being silently finalized. The command now reports an `Analyzed | Skipped` summary.
+- **No more swallowed errors.** `SlowerServiceProvider::createRecord` now reports failures (via `report()` without the raw SQL) instead of silently discarding them, and catches `Throwable` so logging slow queries can never break the application's own request.
+- **Correct cleanup iteration.** `slower:clean` and `slower:analyze` now use `chunkById` to avoid skipping records when the result set changes during iteration.
+
+### Changed
+- **Default recommendation model** changed from the deprecated `gpt-4` (shut down 2026-10-23) to `gpt-5.4-mini`. Pin `SLOWER_AI_RECOMMENDATION_MODEL=gpt-4` to keep the previous behaviour.
+- **PHP 8.4** is now part of the CI test matrix.
+- `openai-php/laravel` constraint raised to `^0.18.0`, and `dependabot/fetch-metadata` bumped to `2.5.0`.
+
+### Documentation
+- README config example synchronized with `slower.php` (`ai_service` documented) and the OpenAI driver/contract extension point explained.
+- Removed the broken third-party screenshot hotlink.
+- `OpenAiDriver` now type-hints `OpenAI\Contracts\ClientContract` instead of the final concrete `Client`, so it can be substituted/faked in tests.
+
 ## Laravel 13 Support - 2026-04-09
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ use HalilCosdu\Slower\Models\SlowLog;
 return [
     'enabled' => env('SLOWER_ENABLED', true),
     'threshold' => env('SLOWER_THRESHOLD', 10000),
+    'ai_service' => env('SLOWER_AI_SERVICE', 'openai'),
     'resources' => [
         'table_name' => (new SlowLog)->getTable(),
         'model' => SlowLog::class,
     ],
     'ai_recommendation' => env('SLOWER_AI_RECOMMENDATION', true),
-    'recommendation_model' => env('SLOWER_AI_RECOMMENDATION_MODEL', 'gpt-4'),
+    'recommendation_model' => env('SLOWER_AI_RECOMMENDATION_MODEL', 'gpt-5.4-mini'),
     'recommendation_use_explain' => env('SLOWER_AI_RECOMMENDATION_USE_EXPLAIN', true),
     'ignore_explain_queries' => env('SLOWER_IGNORE_EXPLAIN_QUERIES', true),
     'ignore_insert_queries' => env('SLOWER_IGNORE_INSERT_QUERIES', true),
@@ -58,10 +59,24 @@ return [
         'organization' => env('OPENAI_ORGANIZATION'),
         'request_timeout' => env('OPENAI_TIMEOUT'),
     ],
-    'prompt' => env('SLOWER_PROMPT', 'As a distinguished database optimization expert, your expertise is invaluable for refining SQL queries to achieve maximum efficiency. Schema json provide list of indexes and column definitions for each table in query. Also analyse the output of EXPLAIN ANALYSE and provide recommendations to optimize query. Please examine the SQL statement provided below including EXPLAIN ANALYSE query plan. Based on your analysis, could you recommend sophisticated indexing techniques or query modifications that could significantly improve performance and scalability?'),
+    'prompt' => env('SLOWER_PROMPT', 'As a distinguished database optimization expert, your expertise is invaluable for refining SQL queries to achieve maximum efficiency. Schema json provide list of indexes and column definitions for each table in query. Also analyse the output of EXPLAIN and provide recommendations to optimize query. Please examine the SQL statement provided below including EXPLAIN query plan. Based on your analysis, could you recommend sophisticated indexing techniques or query modifications that could significantly improve performance and scalability?'),
 ];
 
 ```
+
+#### AI service driver
+
+The `ai_service` key selects the underlying AI provider. The default is `openai`. The OpenAI driver uses [openai-php/laravel](https://github.com/openai-php/laravel) and reads its credentials from the `open_ai` block above. To implement a custom provider, implement `HalilCosdu\Slower\AiServiceDrivers\Contracts\AiServiceDriver`, register a `create{Name}Driver()` method on `AiServiceManager`, and set `SLOWER_AI_SERVICE={name}`.
+
+#### Recommendation model
+
+The default `recommendation_model` is `gpt-5.4-mini` (a currently-supported, low-cost model). To keep the previous behaviour, pin the model explicitly in your `.env`:
+
+```dotenv
+SLOWER_AI_RECOMMENDATION_MODEL=gpt-4
+```
+
+> **Note:** `gpt-4` is scheduled to be shut down on 2026-10-23 — see the [OpenAI deprecations](https://platform.openai.com/docs/deprecations) page. Migrating to a current model is recommended.
 
 You can publish and run the migrations with:
 
@@ -132,12 +147,6 @@ dd($model->raw_sql); /*select count(*) as aggregate from "product_prices" where 
 
 dd($model->recommendation);
 ```
-### Example Screen
-
-<a href="https://i.ibb.co/J2xvB1y/Screenshot-2024-05-11-at-00-24-52.png">
-<img src="https://i.ibb.co/J2xvB1y/Screenshot-2024-05-11-at-00-24-52.png" alt="Screenshot" style="width:100%;">
-</a>
-
 ### Example Recommendation
 In order to improve database performance and scalability, here are some suggestions below:
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "openai-php/laravel": "^0.10.1",
+        "openai-php/laravel": "^0.18.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {

--- a/config/slower.php
+++ b/config/slower.php
@@ -13,7 +13,7 @@ return [
         'model' => SlowLog::class,
     ],
     'ai_recommendation' => env('SLOWER_AI_RECOMMENDATION', true),
-    'recommendation_model' => env('SLOWER_AI_RECOMMENDATION_MODEL', 'gpt-4'),
+    'recommendation_model' => env('SLOWER_AI_RECOMMENDATION_MODEL', 'gpt-5.4-mini'),
     'recommendation_use_explain' => env('SLOWER_AI_RECOMMENDATION_USE_EXPLAIN', true),
     'ignore_explain_queries' => env('SLOWER_IGNORE_EXPLAIN_QUERIES', true),
     'ignore_insert_queries' => env('SLOWER_IGNORE_INSERT_QUERIES', true),
@@ -22,5 +22,5 @@ return [
         'organization' => env('OPENAI_ORGANIZATION'),
         'request_timeout' => env('OPENAI_TIMEOUT'),
     ],
-    'prompt' => env('SLOWER_PROMPT', 'As a distinguished database optimization expert, your expertise is invaluable for refining SQL queries to achieve maximum efficiency. Schema json provide list of indexes and column definitions for each table in query. Also analyse the output of EXPLAIN ANALYSE and provide recommendations to optimize query. Please examine the SQL statement provided below including EXPLAIN ANALYSE query plan. Based on your analysis, could you recommend sophisticated indexing techniques or query modifications that could significantly improve performance and scalability?'),
+    'prompt' => env('SLOWER_PROMPT', 'As a distinguished database optimization expert, your expertise is invaluable for refining SQL queries to achieve maximum efficiency. Schema json provide list of indexes and column definitions for each table in query. Also analyse the output of EXPLAIN and provide recommendations to optimize query. Please examine the SQL statement provided below including EXPLAIN query plan. Based on your analysis, could you recommend sophisticated indexing techniques or query modifications that could significantly improve performance and scalability?'),
 ];

--- a/database/factories/SlowLogFactory.php
+++ b/database/factories/SlowLogFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace HalilCosdu\Slower\Database\Factories;
+
+use HalilCosdu\Slower\Models\SlowLog;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SlowLog>
+ */
+class SlowLogFactory extends Factory
+{
+    protected $model = SlowLog::class;
+
+    public function definition(): array
+    {
+        return [
+            'is_analyzed' => false,
+            'bindings' => [],
+            'sql' => 'select * from users where id = ?',
+            'time' => 15000.0,
+            'connection' => 'Illuminate\Database\SQLiteConnection',
+            'connection_name' => 'testing',
+            'raw_sql' => 'select * from users where id = 1',
+            'recommendation' => null,
+        ];
+    }
+}

--- a/src/AiServiceDrivers/OpenAiDriver.php
+++ b/src/AiServiceDrivers/OpenAiDriver.php
@@ -3,11 +3,11 @@
 namespace HalilCosdu\Slower\AiServiceDrivers;
 
 use HalilCosdu\Slower\AiServiceDrivers\Contracts\AiServiceDriver;
-use OpenAI\Client;
+use OpenAI\Contracts\ClientContract;
 
 class OpenAiDriver implements AiServiceDriver
 {
-    public function __construct(protected Client $client) {}
+    public function __construct(protected ClientContract $client) {}
 
     public function analyze(string $userMessage): ?string
     {

--- a/src/Commands/AnalyzeQuery.php
+++ b/src/Commands/AnalyzeQuery.php
@@ -21,17 +21,28 @@ class AnalyzeQuery extends Command
         }
         $model = config('slower.resources.model');
 
+        $analyzed = 0;
+        $skipped = 0;
+
         (new $model)::query()
             ->where('is_analyzed', false)
-            ->chunk(1000, function ($records) use ($recommendationService) {
+            ->chunkById(1000, function ($records) use ($recommendationService, &$analyzed, &$skipped) {
                 foreach ($records as $record) {
                     $output = $recommendationService->getRecommendation($record);
+
+                    if ($output === null) {
+                        $skipped++;
+
+                        continue;
+                    }
+
+                    $analyzed++;
                     $this->info(Str::words($output, 10));
                 }
             });
 
         $this->line('------------------------------------');
-        $this->comment('All done');
+        $this->comment('Analyzed: '.$analyzed.' | Skipped (no recommendation, will retry on the next run): '.$skipped);
 
         return self::SUCCESS;
     }

--- a/src/Commands/SlowLogCleaner.php
+++ b/src/Commands/SlowLogCleaner.php
@@ -16,7 +16,7 @@ class SlowLogCleaner extends Command
 
         (new $model)::query()
             ->where('created_at', '<', now()->subDays(intval($this->argument('days'))))
-            ->chunk(1000, function ($logs) {
+            ->chunkById(1000, function ($logs) {
                 $logs->each->delete();
             });
 

--- a/src/Services/RecommendationService.php
+++ b/src/Services/RecommendationService.php
@@ -19,18 +19,80 @@ class RecommendationService
             'Sql: '.$record->sql.PHP_EOL;
 
         if (config('slower.recommendation_use_explain', false)) {
-            $plan = collect(DB::select('explain analyse '.$record->raw_sql))->implode('QUERY PLAN', PHP_EOL);
-
-            $userMessage .= 'EXPLAIN ANALYSE output: '.$plan.PHP_EOL;
+            if ($plan = $this->getExplainPlan($record)) {
+                $userMessage .= 'EXPLAIN output: '.$plan.PHP_EOL;
+            }
         }
 
-        return tap(
-            $this->aiService->analyze($userMessage),
-            static fn ($result) => $record->update([
+        $recommendation = $this->aiService->analyze($userMessage);
+
+        // Only mark the record as analyzed when we actually received a
+        // recommendation. Empty results stay retryable so that scheduled
+        // `slower:analyze` runs get another chance at them instead of being
+        // silently finalized.
+        if (! empty($recommendation)) {
+            $record->update([
                 'is_analyzed' => true,
-                'recommendation' => $result,
-            ])
-        );
+                'recommendation' => $recommendation,
+            ]);
+        }
+
+        return $recommendation;
+    }
+
+    /**
+     * Build a safe, non-executing EXPLAIN plan for the captured query.
+     *
+     * Important: this deliberately only ever uses EXPLAIN (never EXPLAIN
+     * ANALYZE). EXPLAIN ANALYZE actually runs the query, which is dangerous
+     * against captured production SQL such as UPDATE/DELETE statements. The
+     * statement form is chosen per database driver; unsupported drivers and
+     * suspicious (multi-statement) input are skipped, and any EXPLAIN failure
+     * is reported without breaking the analysis flow.
+     */
+    private function getExplainPlan($record): ?string
+    {
+        $rawSql = $record->raw_sql;
+
+        // Defensive guard: never explain anything that looks like more than one statement.
+        if (str_contains($rawSql, ';')) {
+            return null;
+        }
+
+        try {
+            $connection = DB::connection($record->connection_name);
+            $driver = $connection->getDriverName();
+        } catch (\Throwable $e) {
+            report(new \RuntimeException('Slower could not resolve the query connection for EXPLAIN: '.$e->getMessage(), 0, $e));
+
+            return null;
+        }
+
+        $explainSql = match ($driver) {
+            'pgsql', 'mysql' => 'EXPLAIN '.$rawSql,
+            'sqlite' => 'EXPLAIN QUERY PLAN '.$rawSql,
+            default => null,
+        };
+
+        if ($explainSql === null) {
+            return null;
+        }
+
+        try {
+            return collect($connection->select($explainSql))
+                ->map(static function ($row) {
+                    if (property_exists($row, 'QUERY PLAN')) {
+                        return $row->{'QUERY PLAN'};
+                    }
+
+                    return json_encode((array) $row);
+                })
+                ->implode(PHP_EOL) ?: null;
+        } catch (\Throwable $e) {
+            report(new \RuntimeException('Slower EXPLAIN failed: '.$e->getMessage(), 0, $e));
+
+            return null;
+        }
     }
 
     private function extractIndexesAndSchemaFromRecord($record): array

--- a/src/SlowerServiceProvider.php
+++ b/src/SlowerServiceProvider.php
@@ -79,8 +79,10 @@ class SlowerServiceProvider extends PackageServiceProvider
                 'connection_name' => $event->connectionName,
                 'raw_sql' => $connection->getQueryGrammar()->substituteBindingsIntoRawSql($event->sql, $bindings),
             ]);
-        } catch (\Exception $e) {
-            //
+        } catch (\Throwable $e) {
+            // Logging slow queries must never break the application's own request.
+            // We surface the failure (without the raw SQL, which may contain sensitive data).
+            report(new \RuntimeException('Failed to store slow query log: '.$e->getMessage(), 0, $e));
         }
     }
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use HalilCosdu\Slower\AiServiceDrivers\Contracts\AiServiceDriver;
 use HalilCosdu\Slower\Commands\AnalyzeQuery;
 use HalilCosdu\Slower\Commands\SlowLogCleaner;
+use HalilCosdu\Slower\Models\SlowLog;
 
 describe('AnalyzeQuery command', function () {
     it('has correct signature', function () {
@@ -12,6 +14,43 @@ describe('AnalyzeQuery command', function () {
     it('has correct description', function () {
         $command = new AnalyzeQuery;
         expect($command->description)->toBe('Analyze and generate a recommendation for the given record.');
+    });
+
+    it('warns and exits successfully when AI recommendation is disabled', function () {
+        config(['slower.enabled' => true]);
+        config(['slower.ai_recommendation' => false]);
+
+        $this->artisan('slower:analyze')->assertSuccessful();
+    });
+
+    it('analyzes pending records and marks them analyzed', function () {
+        $ai = Mockery::mock(AiServiceDriver::class);
+        $ai->shouldReceive('analyze')->andReturn('Add an index on (id).');
+        $this->app->instance(AiServiceDriver::class, $ai);
+
+        SlowLog::factory()->count(2)->create([
+            'is_analyzed' => false,
+            'raw_sql' => 'select * from '.config('slower.resources.table_name'),
+        ]);
+
+        $this->artisan('slower:analyze')->assertSuccessful();
+
+        expect(SlowLog::where('is_analyzed', true)->count())->toBe(2);
+    });
+
+    it('keeps records retryable when the AI returns an empty recommendation', function () {
+        $ai = Mockery::mock(AiServiceDriver::class);
+        $ai->shouldReceive('analyze')->andReturn(null);
+        $this->app->instance(AiServiceDriver::class, $ai);
+
+        SlowLog::factory()->create([
+            'is_analyzed' => false,
+            'raw_sql' => 'select * from '.config('slower.resources.table_name'),
+        ]);
+
+        $this->artisan('slower:analyze')->assertSuccessful();
+
+        expect(SlowLog::first()->is_analyzed)->toBeFalse();
     });
 });
 
@@ -24,5 +63,15 @@ describe('SlowLogCleaner command', function () {
     it('has correct description', function () {
         $command = new SlowLogCleaner;
         expect($command->description)->toBe('Delete records older than 15 days.');
+    });
+
+    it('deletes old records and keeps recent ones', function () {
+        $old = SlowLog::factory()->create(['created_at' => now()->subDays(30)]);
+        $recent = SlowLog::factory()->create(['created_at' => now()->subDays(1)]);
+
+        $this->artisan('slower:clean', ['days' => 15])->assertSuccessful();
+
+        expect(SlowLog::find($old->id))->toBeNull();
+        expect(SlowLog::find($recent->id))->not->toBeNull();
     });
 });

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use HalilCosdu\Slower\Models\SlowLog;
+
 describe('Config', function () {
     it('has default threshold value', function () {
         expect(config('slower.threshold'))->toBe(10000);
@@ -10,7 +12,7 @@ describe('Config', function () {
     });
 
     it('has default recommendation_model value', function () {
-        expect(config('slower.recommendation_model'))->toBe('gpt-4');
+        expect(config('slower.recommendation_model'))->toBe('gpt-5.4-mini');
     });
 
     it('has default enabled value', function () {
@@ -35,7 +37,7 @@ describe('Config', function () {
 
     it('has resources configuration', function () {
         expect(config('slower.resources.table_name'))->not->toBeNull();
-        expect(config('slower.resources.model'))->toBe(\HalilCosdu\Slower\Models\SlowLog::class);
+        expect(config('slower.resources.model'))->toBe(SlowLog::class);
     });
 
     it('has open_ai configuration keys', function () {

--- a/tests/RecommendationServiceTest.php
+++ b/tests/RecommendationServiceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use HalilCosdu\Slower\AiServiceDrivers\Contracts\AiServiceDriver;
+use HalilCosdu\Slower\Models\SlowLog;
+use HalilCosdu\Slower\Services\RecommendationService;
+
+describe('getTableNamesFromRawQuery', function () {
+    $extract = function (string $sql): array {
+        $service = app(RecommendationService::class);
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('getTableNamesFromRawQuery');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $sql);
+    };
+
+    it('extracts a table from a FROM clause', function () use ($extract) {
+        expect($extract('select * from users where id = 1'))->toContain('users');
+    });
+
+    it('extracts tables from JOIN clauses', function () use ($extract) {
+        $tables = $extract('select * from posts inner join users on users.id = posts.user_id');
+        expect($tables)->toContain('posts')->toContain('users');
+    });
+
+    it('extracts a table from an UPDATE statement', function () use ($extract) {
+        expect($extract('update users set name = "halil" where id = 1'))->toContain('users');
+    });
+
+    it('strips double quotes from table names', function () use ($extract) {
+        expect($extract('select * from "users"'))->toContain('users');
+    });
+
+    it('strips backticks from table names', function () use ($extract) {
+        expect($extract('select * from `users`'))->toContain('users');
+    });
+});
+
+describe('RecommendationService::getRecommendation', function () {
+    it('does not mark a record analyzed when the AI returns an empty recommendation', function () {
+        $ai = Mockery::mock(AiServiceDriver::class);
+        $ai->shouldReceive('analyze')->andReturn(null);
+
+        $service = new RecommendationService($ai);
+        $record = SlowLog::factory()->create([
+            'raw_sql' => 'select * from '.config('slower.resources.table_name'),
+        ]);
+
+        expect($service->getRecommendation($record))->toBeNull();
+        expect($record->fresh()->is_analyzed)->toBeFalse();
+        expect($record->fresh()->recommendation)->toBeNull();
+    });
+
+    it('marks a record analyzed and stores a non-empty recommendation', function () {
+        $ai = Mockery::mock(AiServiceDriver::class);
+        $ai->shouldReceive('analyze')->andReturn('Add a composite index on (product_id, price).');
+
+        $service = new RecommendationService($ai);
+        $record = SlowLog::factory()->create([
+            'raw_sql' => 'select * from '.config('slower.resources.table_name'),
+        ]);
+
+        $service->getRecommendation($record);
+
+        expect($record->fresh()->is_analyzed)->toBeTrue();
+        expect($record->fresh()->recommendation)->toBe('Add a composite index on (product_id, price).');
+    });
+
+    it('runs a safe (non-executing) EXPLAIN against the sqlite driver without throwing', function () {
+        $ai = Mockery::mock(AiServiceDriver::class);
+        $ai->shouldReceive('analyze')->andReturn('recommendation');
+
+        $service = new RecommendationService($ai);
+        $record = SlowLog::factory()->create([
+            'raw_sql' => 'select * from '.config('slower.resources.table_name'),
+        ]);
+
+        $service->getRecommendation($record);
+
+        expect($record->fresh()->is_analyzed)->toBeTrue();
+    });
+});
+
+describe('getExplainPlan', function () {
+    $explain = function (string $rawSql) {
+        $ai = Mockery::mock(AiServiceDriver::class);
+        $service = new RecommendationService($ai);
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('getExplainPlan');
+        $method->setAccessible(true);
+
+        $record = SlowLog::factory()->make(['raw_sql' => $rawSql]);
+
+        return $method->invoke($service, $record);
+    };
+
+    it('skips EXPLAIN for multi-statement raw sql', function () use ($explain) {
+        expect($explain('select 1; drop table users'))->toBeNull();
+    });
+});

--- a/tests/SlowerTest.php
+++ b/tests/SlowerTest.php
@@ -2,6 +2,7 @@
 
 use HalilCosdu\Slower\Services\RecommendationService;
 use HalilCosdu\Slower\Slower;
+use Illuminate\Database\Eloquent\Model;
 
 beforeEach(function () {
     $this->mockedRecommendationService = Mockery::mock(RecommendationService::class);
@@ -9,7 +10,7 @@ beforeEach(function () {
 });
 describe('analyze', function () {
     it('throws an exception if the model is not an instance of the configured model', function () {
-        class TestModel extends Illuminate\Database\Eloquent\Model {}
+        class TestModel extends Model {}
         $mockedModel = Mockery::mock(TestModel::class);
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Model must be an instance of '.config('slower.resources.model'));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,10 +27,12 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+        // A fake key so the OpenAI driver can be resolved during tests without
+        // making any real HTTP calls.
+        config()->set('slower.open_ai.api_key', 'test-key');
 
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_laravel_slower_table.php.stub';
+        // Ensure the slow log table exists for behavior tests that touch the DB.
+        $migration = include __DIR__.'/../database/migrations/create_slower_table.php.stub';
         $migration->up();
-        */
     }
 }


### PR DESCRIPTION
Maintenance and quality pass towards **v2.2.0**. No public API breaks. Reviewed jointly with Codex/GPT-5.5 (full plan in the discussion). Tag will be cut on explicit request.

## Fixed
- **Safe EXPLAIN** — `RecommendationService` now resolves the captured query's own connection and runs a *non-executing* `EXPLAIN` (never `EXPLAIN ANALYZE`), with a per-driver statement form (`pgsql`/`mysql` → `EXPLAIN`, `sqlite` → `EXPLAIN QUERY PLAN`, others skipped). Multi-statement input is rejected and EXPLAIN failures are reported without breaking analysis. The previous `explain analyse` was Postgres-only and could actually execute captured production SQL (e.g. `UPDATE`/`DELETE`).
- **Retryable recommendations** — a record is only marked `is_analyzed` when the AI returns a non-empty recommendation. Empty results stay `is_analyzed=false` and are retried on the next scheduled `slower:analyze`. The command now prints an `Analyzed | Skipped` summary.
- **No more swallowed errors** — `createRecord` reports failures via `report()` (without the raw SQL) and catches `Throwable`, so logging slow queries can never break the request.
- **Correct iteration** — `slower:clean` and `slower:analyze` switched to `chunkById`.

## Changed
- Default `recommendation_model`: deprecated `gpt-4` (shut down 2026-10-23) → **`gpt-5.4-mini`**. Verified against [OpenAI deprecations](https://platform.openai.com/docs/deprecations). Pin `SLOWER_AI_RECOMMENDATION_MODEL=gpt-4` to keep old behaviour (see README upgrade note).
- CI now tests **PHP 8.4** (matrix: 8.2/8.3/8.4 × L10–13).
- `openai-php/laravel` → `^0.18.0`, `dependabot/fetch-metadata` → `2.5.0`. Supersedes #51 and #52.

## Docs / internals
- README config example synced with `slower.php`, `ai_service` driver switch documented, broken third-party screenshot removed.
- `OpenAiDriver` now type-hints `OpenAI\Contracts\ClientContract` (substitutable/fakeable).
- +13 behavior tests (`RecommendationServiceTest`, extended `CommandsTest`, `SlowLogFactory`). Suite: **39 passed**. PHPStan level 5: clean. Pint: clean.

## Out of scope (deferred)
- New AI drivers (Ollama/Anthropic), `notify()` notifications, queue-based analysis, retry counter migration — tracked for a future v3.

## Verification
- [x] `composer test` — 39 passed
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `composer format` — clean