### PR TITLE
v3.0.0 — Laravel 11–13 & PHP 8.5 support (drop Laravel 10 / PHP 8.2)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v3
 
       - name: Run PHPStan
-        run: ./vendor/bin/phpstan --error-format=github
+        run: ./vendor/bin/phpstan --error-format=github --memory-limit=1G

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.4, 8.3, 8.2 ]
-        laravel: [ 11.*, 12.*, 13.*]
+        php: [ '8.5', '8.4', '8.3' ]
+        laravel: [ 11.*, 12.*, 13.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 11.*
@@ -30,9 +30,6 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
             carbon: ^3.0
-        exclude:
-          - php: 8.2
-            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -55,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --with-all-dependencies --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `laravel-slower` will be documented in this file.
 
+## v3.0.0 - 2026-07-11
+
+Platform modernization. No public API, config, or database changes — only the supported runtime and the development toolchain moved forward.
+
+### Changed
+- **Requires PHP 8.3+ and Laravel 11, 12, or 13.** Laravel 10 and PHP 8.2 support are dropped. The package already relied on the Laravel 11+ `casts()` model method, so Laravel 10 was effectively unsupported; this makes the constraint honest.
+- **`openai-php/laravel` raised to `^0.20.0`** — the previous `^0.18.0` capped at Laravel 12 and silently blocked Laravel 13 installs.
+- **Modernized the dev/test toolchain** to a single stack: Pest 4, `pest-plugin-laravel` 4 (first line to support Laravel 13), PHPStan 2 / larastan 3 (resolving the PHPStan 1-vs-2 dependency conflict), testbench 9–11.
+- **CI** now covers PHP 8.3–8.5 × Laravel 11–13.
+
+### Removed
+- Dead code: the empty `notify()` hook in `SlowerServiceProvider` and its call site.
+
+### Upgrade
+No application-code, config, or migration changes are required if you already run PHP 8.3+ and Laravel 11+. Still on PHP 8.2 or Laravel 10? Stay on the `^2.3` line.
+
 ## v2.3.0 - 2026-07-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Laravel Slower is a Laravel package that automatically detects slow database queries and uses AI (OpenAI) to suggest optimization strategies like indexing and query modifications. Requires PHP 8.2+ and Laravel 10/11/12/13.
+Laravel Slower is a Laravel package that automatically detects slow database queries and uses AI (OpenAI) to suggest optimization strategies like indexing and query modifications. Requires PHP 8.3+ and Laravel 11/12/13.
 
 ## Common Commands
 
@@ -60,4 +60,4 @@ Test files: `SlowerTest` (core analysis), `ConfigTest` (config defaults), `Comma
 
 ## CI
 
-Tests run on PHP 8.2-8.3 with Laravel 11-13 (`prefer-lowest` and `prefer-stable`). Laravel 13 requires PHP 8.3+. PHPStan and Pint run as separate workflows.
+Tests run on PHP 8.3-8.5 with Laravel 11-13 (`prefer-lowest` and `prefer-stable`), using the Pest 4 / PHPStan 2 (larastan 3) stack. PHPStan and Pint run as separate workflows.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Laravel Slower watches every query your application runs, captures the ones that
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 10.x, 11.x, 12.x or 13.x
+- PHP 8.3+
+- Laravel 11.x, 12.x or 13.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -24,22 +24,23 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "openai-php/laravel": "^0.18.0",
+        "php": "^8.3",
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+        "openai-php/laravel": "^0.20.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
-        "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1 || ^7.10.0",
-        "larastan/larastan": "^2.9 || ^3.0",
-        "orchestra/testbench": "^11.0.0 || ^10.0.0 || ^9.0.0 || ^8.22.0",
-        "pestphp/pest": "^2.34 || ^3.0",
-        "pestphp/pest-plugin-arch": "^2.7 || ^3.0",
-        "pestphp/pest-plugin-laravel": "^2.3 || ^3.0",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3",
+        "larastan/larastan": "^3.0",
+        "laravel/pint": "^1.18",
+        "nunomaduro/collision": "^8.6 || ^9.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^3.0 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "spatie/laravel-ray": "^1.35"
     },
     "autoload": {
@@ -68,7 +69,7 @@
             "@composer run build",
             "@php vendor/bin/testbench serve"
         ],
-        "analyse": "vendor/bin/phpstan analyse",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=1G",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"
@@ -91,6 +92,6 @@
             }
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,4 +8,19 @@ parameters:
         - config
         - database
     tmpDir: build/phpstan
+    # Tell larastan where this package keeps its config and views so the
+    # env()-in-config and view-name checks resolve against the real files.
+    configDirectories:
+        - config
+    viewDirectories:
+        - resources/views
+    ignoreErrors:
+        # The dashboard views are registered under the `slower::` namespace at
+        # runtime (hasViews()); larastan can't resolve namespaced package views
+        # statically. They exist in resources/views and are covered by the
+        # feature tests, so the view-string check is a false positive here.
+        -
+            identifier: argument.type
+            message: '#\$view of function view expects view-string\|null, string given#'
+            path: src/Http/Controllers/DashboardController.php
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     colors="true"
@@ -20,16 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
     <source>
         <include>
             <directory suffix=".php">./src</directory>

--- a/src/Commands/AnalyzeQuery.php
+++ b/src/Commands/AnalyzeQuery.php
@@ -24,7 +24,7 @@ class AnalyzeQuery extends Command
         $analyzed = 0;
         $skipped = 0;
 
-        (new $model)::query()
+        $model::query()
             ->where('is_analyzed', false)
             ->chunkById(1000, function ($records) use ($recommendationService, &$analyzed, &$skipped) {
                 foreach ($records as $record) {

--- a/src/SlowerServiceProvider.php
+++ b/src/SlowerServiceProvider.php
@@ -86,7 +86,6 @@ class SlowerServiceProvider extends PackageServiceProvider
                 }
 
                 $this->createRecord($event, $event->connection);
-                $this->notify($event, $event->connection);
             });
         }
     }
@@ -102,11 +101,11 @@ class SlowerServiceProvider extends PackageServiceProvider
         $bindings = $this->normalizeBindings($event->bindings);
 
         try {
-            (new $model)::query()->create([
+            $model::query()->create([
                 'bindings' => $bindings,
                 'sql' => $event->sql,
                 'time' => $event->time,
-                'connection' => get_class($event->connection),
+                'connection' => $event->connection::class,
                 'connection_name' => $event->connectionName,
                 'raw_sql' => $connection->getQueryGrammar()->substituteBindingsIntoRawSql($event->sql, $bindings),
             ]);
@@ -136,10 +135,5 @@ class SlowerServiceProvider extends PackageServiceProvider
         }
 
         return [$bindings];
-    }
-
-    private function notify(QueryExecuted $event, Connection $connection)
-    {
-        //
     }
 }

--- a/src/Support/SqlFormatter.php
+++ b/src/Support/SqlFormatter.php
@@ -33,8 +33,9 @@ class SqlFormatter
 
         $formatted = '';
 
+        // PREG_SPLIT_NO_EMPTY guarantees every segment is a non-empty string.
         foreach ($segments as $segment) {
-            $isQuoted = $segment !== '' && in_array($segment[0], ["'", '"', '`'], true);
+            $isQuoted = in_array($segment[0], ["'", '"', '`'], true);
 
             $formatted .= $isQuoted
                 ? $segment

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,9 @@
+<?php
+
+arch('the package ships no leftover debugging statements')
+    ->expect(['dd', 'dump', 'ray', 'var_dump', 'var_export'])
+    ->not->toBeUsed();
+
+arch('the package is free of PHP smells')
+    ->preset()
+    ->php();

--- a/tests/DashboardResilienceTest.php
+++ b/tests/DashboardResilienceTest.php
@@ -55,6 +55,12 @@ class LocklessTestStore implements Store
         return $this->put($key, $value, 0);
     }
 
+    // Present on the Laravel 13 Store contract; harmless as an extra method on 11/12.
+    public function touch($key, $seconds)
+    {
+        return true;
+    }
+
     public function forget($key)
     {
         unset($this->items[$key]);


### PR DESCRIPTION
## v3.0.0 — platform modernization (Laravel 11–13, PHP 8.3–8.5)

Drops Laravel 10 & PHP 8.2, adds genuine Laravel 13 + PHP 8.5 support, and modernizes the dev toolchain. **No public API, config, or database changes** — only the supported runtime and the tooling moved forward.

### Why
The package already used the Laravel 11+ `casts()` model method, so Laravel 10 was effectively unsupported while `composer.json` still advertised `^10.0`. Worse, `openai-php/laravel: ^0.18.0` capped at `laravel/framework ^11.29|^12.12` — it **silently blocked Laravel 13 installs**, so the "Laravel 13 support" shipped earlier couldn't actually resolve.

### Changes
- **`require`**: `php: ^8.3`, `illuminate/contracts: ^11.0 || ^12.0 || ^13.0`, `openai-php/laravel: ^0.20.0` (the real L13 unblock).
- **Dev stack → one modern line**: Pest 4, `pest-plugin-laravel` 4 (first version supporting Laravel 13), PHPStan 2 / larastan 3 (resolves the PHPStan 1-vs-2 dependency conflict), testbench 9–11, collision 8.6/9. `minimum-stability: stable` (was `dev`) for reproducible resolves.
- **`phpunit.xml.dist`**: migrated to the 12.5 schema; coverage is now opt-in (via `composer test-coverage`), so a normal run no longer needs a coverage driver.
- **`phpstan.neon.dist`**: point larastan at the package `config/` and `resources/views/` dirs; one narrowly-scoped ignore for the view-string false positive on the `slower::`-namespaced views; `--memory-limit=1G` for the analyse script and PHPStan CI job.
- **Dead code removed**: the empty `notify()` hook in `SlowerServiceProvider` and its call site.
- **Laravel style**: `$model::query()` (was `(new $model)::query()`), `$event->connection::class` (was `get_class(...)`), and a redundant comparison dropped in `SqlFormatter`.
- **CI**: matrix is now PHP 8.3–8.5 × Laravel 11–13, each cell resolved with `--with-all-dependencies`; the old PHP-8.2/L13 exclusion is gone.
- **Test harness**: added the Laravel 13 Cache `Store::touch()` method to the lockless test store.

### Verification
- Local suite green on **Laravel 11, 12, 13** (and 13 `prefer-lowest`): 112 tests / 242 assertions, on PHP 8.4; **PHP 8.5** confirmed green too.
- PHPStan 2 (larastan 3) level 5 clean; Pint clean.
- Plan produced by a multi-model council (unanimous); diff passed a clean recursive code review.

### Release note
This is a **major** bump because it drops declared Laravel 10 / PHP 8.2 support. Users on those platforms should stay on the `^2.x` line. Merging + tagging `v3.0.0` is left to the maintainer.

> Heads-up: GitHub Actions is currently failing to provision runners across all branches (an account-level issue, not this change), so CI can't validate the matrix here yet — it was validated locally instead.
